### PR TITLE
Fallback to default translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slack-feedback",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React component for gathering user feedback to send to slack.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/slack-feedback.js
+++ b/src/slack-feedback.js
@@ -56,7 +56,7 @@ class SlackFeedback extends React.Component {
 
     return typeof translations === 'object' && key in translations
       ? translations[key]
-      : ''
+      : defaultTranslations[key] || ''
   }
 
   handleChange = key => event =>

--- a/src/slack-feedback.spec.js
+++ b/src/slack-feedback.spec.js
@@ -90,6 +90,18 @@ describe('SlackFeedback', () => {
     it('should return an empty string if not found', () => {
       expect(component.instance().translate('not.available')).toEqual('')
     })
+
+    it('should return the correct value from a translation prop', () => {
+      component.setProps({ translations: { 'trigger.text': 'Feedback' } })
+      expect(component.instance().translate('trigger.text')).toEqual('Feedback')
+    })
+
+    it('should return default translations if translation prop is provided', () => {
+      component.setProps({ translations: { 'trigger.text': 'Feedback' } })
+      expect(component.instance().translate('submit.text')).toEqual(
+        'Send Feedback'
+      )
+    })
   })
 
   describe('presentational', () => {


### PR DESCRIPTION
If you pass 1 translation as a prop, all other translations return an empty string.

```js
  <SlackFeedback
    channel="#general"
    theme={themes.dark} // (optional) See src/themes/default for default theme
    user="Slack Feedback" // The logged in user (default = "Unknown User")
    onImageUpload={(image, success,error) => 
      uploadImage(image)
        .then(({ url }) => success(url))
        .catch(error)
    }
    onSubmit={(payload, success, error) => 
      sendToServer(payload)
        .then(success)
        .catch(error)
     }
    translations={{ 'trigger.text': 'Feedback' }} // Add one translation here to change trigger text.
  />
```

Wouldn't it be expected that default translations would be the fallback if only one is passed as a prop?

