### PR TITLE
Bring back ability to update styling of button/heading icon/text separately

### DIFF
--- a/src/slack-feedback.js
+++ b/src/slack-feedback.js
@@ -377,9 +377,10 @@ class SlackFeedback extends React.Component {
               {this.props.renderHeaderContent ? (
                 this.props.renderHeaderContent(this.translate('header.title'))
               ) : (
-                <React.Fragment>
-                  {this.props.showIcon ? <Icon /> : null} {this.translate('header.title')}
-                </React.Fragment>
+                <>
+                  {this.props.showIcon ? <Icon /> : null}{' '}
+                  {this.translate('header.title')}
+                </>
               )}
               <CloseButton className="close" onClick={this.close}>
                 {this.translate('close')}
@@ -441,9 +442,10 @@ class SlackFeedback extends React.Component {
             {this.props.renderTriggerContent ? (
               this.props.renderTriggerContent(this.translate('trigger.text'))
             ) : (
-              <React.Fragment>
-                {this.props.showIcon ? <Icon /> : null} {this.translate('trigger.text')}
-              </React.Fragment>
+              <>
+                {this.props.showIcon ? <Icon /> : null}{' '}
+                {this.translate('trigger.text')}
+              </>
             )}
           </Trigger>
         </StyledSlackFeedback>
@@ -493,7 +495,7 @@ SlackFeedback.defaultProps = {
     { value: FEATURE, label: defaultTranslations['feedback.type.feature'] }
   ],
   icon: () => <SlackIcon />,
-  renderTrigger: undefined,
+  renderTriggerContent: undefined,
   renderHeaderContent: undefined,
   onClose: () => {},
   onOpen: () => {},

--- a/src/slack-feedback.js
+++ b/src/slack-feedback.js
@@ -374,8 +374,13 @@ class SlackFeedback extends React.Component {
         >
           <Container className={cx('fadeInUp', { active: open })}>
             <Header>
-              {this.props.showIcon ? <Icon /> : null}{' '}
-              {this.translate('header.title')}
+              {this.props.renderHeaderContent ? (
+                this.props.renderHeaderContent(this.translate('header.title'))
+              ) : (
+                <React.Fragment>
+                  {this.props.showIcon ? <Icon /> : null} {this.translate('header.title')}
+                </React.Fragment>
+              )}
               <CloseButton className="close" onClick={this.close}>
                 {this.translate('close')}
               </CloseButton>
@@ -433,8 +438,13 @@ class SlackFeedback extends React.Component {
           </Container>
 
           <Trigger className={cx({ active: open })} onClick={this.toggle}>
-            {this.props.showIcon ? <Icon /> : null}{' '}
-            {this.translate('trigger.text')}
+            {this.props.renderTriggerContent ? (
+              this.props.renderTriggerContent(this.translate('trigger.text'))
+            ) : (
+              <React.Fragment>
+                {this.props.showIcon ? <Icon /> : null} {this.translate('trigger.text')}
+              </React.Fragment>
+            )}
           </Trigger>
         </StyledSlackFeedback>
       </ThemeProvider>
@@ -454,6 +464,8 @@ SlackFeedback.propTypes = {
     })
   ),
   icon: PropTypes.func,
+  renderTriggerContent: PropTypes.func,
+  renderHeaderContent: PropTypes.func,
   onClose: PropTypes.func,
   onImageUpload: PropTypes.func.isRequired,
   onOpen: PropTypes.func,
@@ -481,6 +493,8 @@ SlackFeedback.defaultProps = {
     { value: FEATURE, label: defaultTranslations['feedback.type.feature'] }
   ],
   icon: () => <SlackIcon />,
+  renderTrigger: undefined,
+  renderHeaderContent: undefined,
   onClose: () => {},
   onOpen: () => {},
   open: false,


### PR DESCRIPTION
Since v2 it seems we've lost the ability to separately define the styling of the heading of the feedback modal and styling of the button caused by the dropping of the `buttonText` and `title` props.

This PR adds optional render functions for the button text and header text which will take precedent over the `icon` prop if it's provided.

Our use case is simple - we've got a dark background on the modal header and a light background on the trigger button. We want to show a light icon in the heading and a dark icon on the trigger, each of which we also need to ability to tweak spacing/layout.

Example usage:

```
<SlackFeedback
  ...
  theme={{ trigger: { backgroundColor: 'white', color: '#333' } }}
  renderTriggerContent={text => (
    <FeedbackLabel>
      <BrandIcon width="20px" height="20px" />
      {text}
    </FeedbackLabel>
  )}
  renderHeadingContent={heading => (
    <FeedbackTitle>
      <BrandIcon fill="white" width="20px" height="20px" />
      {heading}
    </FeedbackTitle>
  )}
/>
``` 

where `FeedbackLabel` and `FeedbackTitle` in this case are simple styled component `<span>` elements which allow us to control the spacing/style of the icon and translated text. 