### PR TITLE
Update `trigger.border` to allow full control over the trigger's border

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -166,7 +166,7 @@ const Trigger = styled.div`
   font-weight: ${theme('trigger.fontWeight', 'normal')};
   background: ${theme('trigger.backgroundColor')};
   color: ${theme('trigger.color')};
-  border: 1px solid ${theme('trigger.border')};
+  border: ${theme('trigger.border')};
   white-space: nowrap;
   padding: ${theme('trigger.padding')};
   border-radius: ${theme('trigger.borderRadius')};


### PR DESCRIPTION
Right now only the border colour can be changed, which doesn't allow for much customisation.